### PR TITLE
Fixed cleaning class files on Mac OS X terminal

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 echo "Removing class files"
-rm `find -name '*.class'`
+rm `find . -name '*.class'`
 echo "Compiling"
 javac -Xlint:deprecation -Xlint:unchecked RSBot.java


### PR DESCRIPTION
I couldn't test if it works on other systems, but on Mac OS X terminal it required the directory.
I used **'.'** for the current directory.