### PR TITLE
Add support for Java object macros

### DIFF
--- a/Aiden/obj-java.rive
+++ b/Aiden/obj-java.rive
@@ -1,0 +1,11 @@
+// Tests the com.rivescript.lang.Java handler.
+
+! local concat = space
+
++ reverse *{weight=2}
+- Ok: <call>javatest <star></call>
+
++ java test
+* <get java> <> undefined => Last time you used "reverse ___", I set
+^ the "java" user variable to the following: <get java>.
+- Say something like "reverse hello world" and then say "java test" again.

--- a/ExampleMacro.java
+++ b/ExampleMacro.java
@@ -1,0 +1,32 @@
+/**
+ * An example object macro written in Java.
+ *
+ * To define a Java object macro, you must implement the interface
+ * com.rivescript.ObjectMacro and register it using setSubroutine().
+ *
+ * This macro does two things: returns their message reversed, and sets
+ * a user variable named `java`.
+ *
+ * This implements the `reverse` object macro used in Aiden/obj-java.rive
+ *
+ * See RSBot.java for more details.
+ */
+
+import com.rivescript.ObjectMacro;
+import java.lang.String;
+import java.lang.StringBuilder;
+
+public class ExampleMacro implements com.rivescript.ObjectMacro {
+	public String call (com.rivescript.RiveScript rs, String[] args) {
+		String message = String.join(" ", args);
+
+		// To get/set user variables for the user, you can use currentUser
+		// to find their ID and then use the usual methods.
+		String user = rs.currentUser();
+		rs.setUservar(user, "java", "This variable was set by Java "
+			+ "when you said 'reverse " + message + "'");
+
+		// Reverse their message and return it.
+		return new StringBuilder(message).reverse().toString();
+	}
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Noah Petherbridge
+Copyright (c) 2016 Noah Petherbridge
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ all: build
 build: clean
 	javac RSBot.java
 
+# `make run` to build and run the bot
+run: clean build
+	java RSBot
+
 # `make test` to run unit tests
 test: clean
 	cd tests; \

--- a/README.md
+++ b/README.md
@@ -7,12 +7,20 @@ This is *BETA QUALITY SOFTWARE* and hasn't been field tested as much as some of
 the other RiveScript libraries in other languages.
 
 It is feature complete syntax-wise: it supports all of the RiveScript directives
-and tags, but it doesn't natively support any object macros yet (there is
-example code included for using Perl object macros though). Long term plans
-include adding native JavaScript support.
+and tags, but it doesn't natively support any dynamic language for object macros.
+You can define object macros in Java at compile-time, and there's an example
+that bridges Perl code; long-term plans include building in native support for
+JavaScript.
+
+This repository is a little bit light on examples; most of the examples for how
+to do things are found in the source of `RSBot.java` and the RiveScript files
+in the `Aiden/` directory. These demonstrate things like Java object macros,
+using the Perl macro bridge, etc.
 
 If you find a way to crash this library, please tell me how you did it so I can
 improve this library!
+
+Contributions are welcome. See `CONTRIBUTING.md` for more information.
 
 ## Documentation
 
@@ -28,6 +36,7 @@ These commands may be used at your input prompt in RSBot:
     /quit        - Quit the program
     /dump topics - Dump the internal topic/trigger/reply struct (debugging)
     /dump sorted - Dump the internal trigger sort buffers (debugging)
+    /last        - Print the last trigger you matched.
 
 ## Makefile
 
@@ -35,6 +44,7 @@ I use a GNU Makefile to simplify builds and other commands (feel free to
 send a pull request to switch to Ant or something). Useful commands:
 
 * `make build`: compiles RSBot.java and, therefore, RiveScript.
+* `make run`: compiles RSBot.java and immediately runs it.
 * `make test`: run unit tests with JUnit.
 * `make clean`: cleans up `.class` files.
 * `make javadoc`: deletes the `doc/` folder and recreates it with the `javadoc`
@@ -42,11 +52,11 @@ send a pull request to switch to Ant or something). Useful commands:
 
 ## QUICK START
 
-Compile RSBot.java using `javac`. The preferred way is to run `build.sh` if you
-have a bash shell.
+Compile RSBot.java using `make build`. If you're running on Windows and don't
+have a Make program installed, you can compile the bot with the `javac` command
+directly:
 
-    Unix:   $ ./build.sh
-            $ javac RSBot.java
+    Unix:   $ make build
     Win32:  > javac RSBot.java
 
 Then execute `RSBot` to begin chatting with the demo Eliza-based bot that
@@ -72,7 +82,7 @@ And then type `make test` to run the unit tests.
 ```
 The MIT License (MIT)
 
-Copyright (c) 2015 Noah Petherbridge
+Copyright (c) 2016 Noah Petherbridge
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/RSBot.java
+++ b/RSBot.java
@@ -6,6 +6,17 @@ import com.rivescript.RiveScript;
 
 public class RSBot {
 	public static void main (String[] args) {
+		// Print a fancy banner.
+		System.out.println(""
+			+ "      .   .       \n"
+			+ "     .:...::      RiveScript Java // RSBot\n"
+			+ "    .::   ::.     Version: " + com.rivescript.RiveScript.VERSION + "\n"
+			+ " ..:;;. ' .;;:..  \n"
+			+ "    .  '''  .     Type '/quit' to quit.\n"
+			+ "     :;,:,;:      Type '/help' for more options.\n"
+			+ "     :     :      \n"
+		);
+
 		// Let the user specify debug mode!
 		boolean debug = false;
 		for (int i = 0; i < args.length; i++) {
@@ -18,8 +29,11 @@ public class RSBot {
 		System.out.println(":: Creating RS Object");
 		RiveScript rs = new RiveScript(debug);
 
-		// Create a handler for Perl objects.
+		// Create a handler for Perl as an object macro language.
 		rs.setHandler("perl", new com.rivescript.lang.Perl(rs, "./lang/rsp4j.pl"));
+
+		// Define an object macro in Java.
+		rs.setSubroutine("javatest", new ExampleMacro());
 
 		// Load and sort replies
 		System.out.println(":: Loading replies");
@@ -48,6 +62,18 @@ public class RSBot {
 			}
 			else if (message.equals("/dump sorted")) {
 				rs.dumpSorted();
+			}
+			else if (message.equals("/last")) {
+				System.out.println("You last matched: "
+					+ rs.lastMatch("localuser"));
+			}
+			else if (message.equals("/help")) {
+				System.out.println("Available commands:\n"
+					+ "  /last           Print the last matched trigger.\n"
+					+ "  /dump topics    Pretty-print the topic structure.\n"
+					+ "  /dump sorted    Pretty-print the sorted trigger structure.\n"
+					+ "  /help           Show this message.\n"
+					+ "  /quit           Exit the program.\n");
 			}
 			else {
 				String reply = rs.reply("localuser", message);

--- a/com/rivescript/Client.java
+++ b/com/rivescript/Client.java
@@ -1,7 +1,7 @@
 /*
 	com.rivescript.RiveScript - The Official Java RiveScript Interpreter
 
-	Copyright (c) 2015 Noah Petherbridge
+	Copyright (c) 2016 Noah Petherbridge
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal

--- a/com/rivescript/ClientManager.java
+++ b/com/rivescript/ClientManager.java
@@ -1,7 +1,7 @@
 /*
 	com.rivescript.RiveScript - The Official Java RiveScript Interpreter
 
-	Copyright (c) 2015 Noah Petherbridge
+	Copyright (c) 2016 Noah Petherbridge
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal

--- a/com/rivescript/Inheritance.java
+++ b/com/rivescript/Inheritance.java
@@ -1,7 +1,7 @@
 /*
 	com.rivescript.RiveScript - The Official Java RiveScript Interpreter
 
-	Copyright (c) 2015 Noah Petherbridge
+	Copyright (c) 2016 Noah Petherbridge
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal

--- a/com/rivescript/ObjectHandler.java
+++ b/com/rivescript/ObjectHandler.java
@@ -23,4 +23,15 @@ public interface ObjectHandler {
 	 * @param args The argument list from the call tag.
 	 */
 	public String onCall (String name, String user, String[] args);
+
+	/**
+	 * Set a Java class to handle the macro directly.
+	 *
+	 * This is only useful to the built-in Java handler; other handlers
+	 * do not need to implement this function.
+	 *
+	 * @param name The name of the object macro.
+	 * @param impl An implementation class of com.rivescript.ObjectMacro.
+	 */
+	public void setClass (String name, com.rivescript.ObjectMacro impl);
 }

--- a/com/rivescript/ObjectMacro.java
+++ b/com/rivescript/ObjectMacro.java
@@ -1,0 +1,19 @@
+package com.rivescript;
+
+/**
+ * Interface for object macros written in Java.
+ */
+
+public interface ObjectMacro {
+	/**
+	 * The implementation of your object macro function.
+	 *
+	 * This code is executed when a `<call>` tag in a RiveScript reply
+	 * wants to call your object macro.
+	 *
+	 * @param rs   A reference to the parent RiveScript instance.
+	 * @param args An array of the word-arguments from the call tag.
+	 * @return A string result of your macro.
+	 */
+	public String call (com.rivescript.RiveScript rs, String[] args);
+}

--- a/com/rivescript/StringCompare.java
+++ b/com/rivescript/StringCompare.java
@@ -1,7 +1,7 @@
 /*
 	com.rivescript.RiveScript - The Official Java RiveScript Interpreter
 
-	Copyright (c) 2015 Noah Petherbridge
+	Copyright (c) 2016 Noah Petherbridge
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal

--- a/com/rivescript/Topic.java
+++ b/com/rivescript/Topic.java
@@ -1,7 +1,7 @@
 /*
 	com.rivescript.RiveScript - The Official Java RiveScript Interpreter
 
-	Copyright (c) 2015 Noah Petherbridge
+	Copyright (c) 2016 Noah Petherbridge
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal

--- a/com/rivescript/TopicManager.java
+++ b/com/rivescript/TopicManager.java
@@ -1,7 +1,7 @@
 /*
 	com.rivescript.RiveScript - The Official Java RiveScript Interpreter
 
-	Copyright (c) 2015 Noah Petherbridge
+	Copyright (c) 2016 Noah Petherbridge
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal

--- a/com/rivescript/Trigger.java
+++ b/com/rivescript/Trigger.java
@@ -1,7 +1,7 @@
 /*
 	com.rivescript.RiveScript - The Official Java RiveScript Interpreter
 
-	Copyright (c) 2015 Noah Petherbridge
+	Copyright (c) 2016 Noah Petherbridge
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal

--- a/com/rivescript/Util.java
+++ b/com/rivescript/Util.java
@@ -1,7 +1,7 @@
 /*
 	com.rivescript.RiveScript - The Official Java RiveScript Interpreter
 
-	Copyright (c) 2015 Noah Petherbridge
+	Copyright (c) 2016 Noah Petherbridge
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal

--- a/com/rivescript/lang/Java.java
+++ b/com/rivescript/lang/Java.java
@@ -1,0 +1,71 @@
+package com.rivescript.lang;
+
+import java.lang.String;
+import java.util.HashMap;
+
+/**
+ * Java programming language support for RiveScript-Java.
+ *
+ * Note that since Java must be compiled before running, this object
+ * macro language is only available at compile-time using the
+ * setSubroutine() function. Inline Java code can't be parsed and
+ * compiled from RiveScript source files.
+ */
+
+public class Java implements com.rivescript.ObjectHandler {
+	private com.rivescript.RiveScript master;
+	private HashMap<String, com.rivescript.ObjectMacro> handlers =
+		new HashMap<String, com.rivescript.ObjectMacro>();
+
+	/**
+	 * Create a Java handler.
+	 *
+	 * @param rivescript Instance of your RiveScript object.
+	 */
+	public Java (com.rivescript.RiveScript rivescript) {
+		this.master = rivescript;
+	}
+
+	/**
+	 * Handler for when object code is read by RiveScript.
+	 *
+	 * We can't dynamically evaluate Java code, so this function just
+	 * logs an error.
+	 */
+	public boolean onLoad (String name, String[] code) {
+		System.err.println("NOTICE: Can't dynamically eval Java code from an "
+			+ "inline object macro! Use the setSubroutine() function instead "
+			+ "to define an object at compile time.");
+		return false;
+	}
+
+	/**
+	 * Handler for directly setting an implementation class for a macro.
+	 *
+	 * This is called by the parent RiveScript object's `setSubroutine()`
+	 * function.
+	 */
+	public void setClass (String name, com.rivescript.ObjectMacro impl) {
+		this.handlers.put(name, impl);
+	}
+
+	/**
+	 * Handler for when a user invokes the object.
+	 *
+	 * This should return the reply text from the object.
+	 *
+	 * @param name The name of the object being called.
+	 * @param user The calling user's ID.
+	 * @param args The argument list from the call tag.
+	 */
+	public String onCall (String name, String user, String[] args) {
+		// Does the object macro exist?
+		com.rivescript.ObjectMacro macro = this.handlers.get(name);
+		if (macro == null) {
+			return "[ERR: Object Not Found]";
+		}
+
+		// Call it!
+		return macro.call(this.master, args);
+	}
+}

--- a/com/rivescript/lang/Perl.java
+++ b/com/rivescript/lang/Perl.java
@@ -124,4 +124,6 @@ public class Perl implements com.rivescript.ObjectHandler {
 			return "[ERR: JSONException: " + e.getMessage() + "]";
 		}
 	}
+
+	public void setClass (String name, com.rivescript.ObjectMacro impl) {}
 }


### PR DESCRIPTION
This finally adds support for compile-time Java object macros to be used, bringing the API function `setSubroutine()` that most of the other implementations have.

## New API Features

* `void setSubroutine (String name, com.rivescript.ObjectMacro impl)` -- to set an object macro written in Java at compile-time of your application.
* `string currentUser ()` -- retrieve the current user's ID from within a Java object macro.
* `string lastMatch (String username)` -- retrieve the text of the last matched trigger for that user. The RSBot example bot calls this when you use the `/last` command.

## Misc Changes

* Version numbering is switching to [semver](http://semver.org/), so `com.rivescript.RiveScript.VERSION` is a string now like `"0.6.0"`

## Object Macro Example

To implement an object macro written in Java you must implement the `ObjectMacro` class. Example:

```java
public class MyMacro implements com.rivescript.ObjectMacro {
    public String call (com.rivescript.RiveScript rs, String[] args) {
        return "Hello, Java!";
    }
}
```

And register it using the `setSubroutine()` API function:

```java
rs.setSubroutine("mine", new MyMacro());
```

And it's callable within RiveScript:

```rivescript
+ test my macro
- Here goes nothing: <call>mine</call>
```