### PR TITLE
[WIP] Publish to Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.rivescript</groupId>
+	<artifactId>rivescript</artifactId>
+	<version>0.6.0</version>
+
+	<name>com.rivescript:RiveScript</name>
+	<description>RiveScript is a chatbot scripting language.</description>
+	<url>https://github.com/aichaos/rivescript-java</url>
+
+	<licenses>
+		<license>
+			<name>GPL License, version 2</name>
+			<url>https://www.gnu.org/licenses/gpl2.txt</url>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<name>Noah Petherbridge</name>
+			<email>root@kirsle.net</email>
+			<organization>AiChaos</organization>
+			<organizationUrl>https://www.aichaos.com/</organizationUrl>
+		</developer>
+	</developers>
+
+	<scm>
+		<connection>scm:git:git@github.com:aichaos/rivescript-java.git</connection>
+		<developerConnection>scm:git:git@github.com:aichaos/rivescript-java.git</developerConnection>
+		<url>git@github.com:aichaos/rivescript-java.git</url>
+	</scm>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20160810</version>
+			<type>jar</type>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.+</version>
+			<type>jar</type>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>sign-artifacts</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>sign</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>1.6.3</version>
+				<extensions>true</extensions>
+				<configuration>
+					<serverId>ossrh</serverId>
+					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+					<stagingProfileId>19375019933d12</stagingProfileId>
+					<autoReleaseAfterClose>true</autoReleaseAfterClose>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<additionalparam>-Xdoclint:none</additionalparam>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
This branch gets the repository ready to eventually start publishing `com.rivescript.RiveScript` to Maven, which will fix #12.

RiveScript-Java is my first real Java project and this will be the first time publishing a Java module to a repository so this should be fun. :wink:

Rough progress report:
- [x] Make JIRA account with The Central Repository (Sonatype)
- [x] Reserve the groupId `com.rivescript`: [OSSRH-25413](https://issues.sonatype.org/browse/OSSRH-25413)
- [x] Make a `pom.xml` file with all the required fields Maven needs.
- [x] Set up a GPG key pair for signing releases (a good excuse to finally set up my [keybase](https://keybase.io/) account).
- [ ] Get deployment to the Sonatype Nexus staging server working (probably using Gradle since I already have a `build.gradle` since #6)
- [ ] ??? (Test the staging repository to verify installing the module works as it should)
- [ ] Profit! (Get it on The Central Repository)
## Relevant Docs
- [OSSRH Guide](http://central.sonatype.org/pages/ossrh-guide.html)
- [Deploying with Gradle](http://central.sonatype.org/pages/gradle.html)
- [How to upload your Java artifact to Maven Central](https://blog.idrsolutions.com/2015/06/how-to-upload-your-java-artifact-to-maven-central/)
- [The GPG Manual](https://www.gnupg.org/gph/en/manual.html)
