### PR TITLE
Removed the hardcoded VERSION constant in favour of package version

### DIFF
--- a/rivescript-core/src/main/java/com/rivescript/RiveScript.java
+++ b/rivescript-core/src/main/java/com/rivescript/RiveScript.java
@@ -66,16 +66,10 @@ import java.util.regex.Pattern;
 public class RiveScript {
 
 	// Private class variables.
-	private boolean debug = false;        // Debug mode
-	private int depth = 50;           // Recursion depth limit
-	private String error = "";           // Last error text
+	private boolean debug = false;             // Debug mode
+	private int depth = 50;                    // Recursion depth limit
+	private String error = "";                 // Last error text
 	private static Random rand = new Random(); // A random number generator
-
-	// Module version
-	/**
-	 * The version of the RiveScript Java library.
-	 */
-	public static final String VERSION = "0.7.0-SNAPSHOT"; // TODO should be retrieved from manifest file
 
 	// Constant RiveScript command symbols.
 	private static final double RS_VERSION = 2.0; // This implements RiveScript 2.0
@@ -97,17 +91,17 @@ public class RiveScript {
 
 	// Object handlers
 	private HashMap<String, ObjectHandler> handlers = new HashMap<>();
-	private HashMap<String, String> objects = new HashMap<>(); // name->language mappers
+	private HashMap<String, String> objects = new HashMap<>();        // name->language mappers
 
 	// Simpler internal data structures.
-	private Vector<String> vTopics = new Vector<>(); // vector containing topic list (for quicker lookups)
-	private HashMap<String, String> globals = new HashMap<>(); // ! global
-	private HashMap<String, String> vars = new HashMap<>(); // ! var
+	private Vector<String> vTopics = new Vector<>();                  // vector containing topic list (for quicker lookups)
+	private HashMap<String, String> globals = new HashMap<>();        // ! global
+	private HashMap<String, String> vars = new HashMap<>();           // ! var
 	private HashMap<String, Vector<String>> arrays = new HashMap<>(); // ! array
-	private HashMap<String, String> subs = new HashMap<>(); // ! sub
-	private String[] subs_s = null;            // sorted subs
-	private HashMap<String, String> person = new HashMap<>(); // ! person
-	private String[] person_s = null;            // sorted persons
+	private HashMap<String, String> subs = new HashMap<>();           // ! sub
+	private String[] subs_s = null;                                   // sorted subs
+	private HashMap<String, String> person = new HashMap<>();         // ! person
+	private String[] person_s = null;                                 // sorted persons
 
 	// The current user ID when reply() is called.
 	private String currentUser = null;
@@ -2141,5 +2135,16 @@ public class RiveScript {
 		if (this.debug) {
 			e.printStackTrace();
 		}
+	}
+
+	/**
+	 * Return the full version string of the present RiveScript Java codebase,
+	 * or {@code null} if it cannot be determined.
+	 *
+	 * @see Package#getImplementationVersion()
+	 */
+	public static String getVersion() {
+		Package pkg = RiveScript.class.getPackage();
+		return (pkg != null ? pkg.getImplementationVersion() : null);
 	}
 }

--- a/samples/rsbot/build.gradle
+++ b/samples/rsbot/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
-    compile project(":rivescript-core")
+	compile project(":rivescript-core")
 }
 
 task runApp(type: JavaExec) {
-    classpath = sourceSets.main.runtimeClasspath
-    main = "RSBot"
-    standardInput = System.in
+	classpath = sourceSets.main.runtimeClasspath
+	main = "RSBot"
+	standardInput = System.in
 }

--- a/samples/rsbot/src/main/java/RSBot.java
+++ b/samples/rsbot/src/main/java/RSBot.java
@@ -26,6 +26,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.lang.String;
 import com.rivescript.RiveScript;
+import com.rivescript.lang.Perl;
 
 /**
  * @author Noah Petherbridge
@@ -36,7 +37,7 @@ public class RSBot {
 		System.out.println(""
 			+ "      .   .       \n"
 			+ "     .:...::      RiveScript Java // RSBot\n"
-			+ "    .::   ::.     Version: " + com.rivescript.RiveScript.VERSION + "\n"
+			+ "    .::   ::.     Version: " + RiveScript.getVersion() + "\n"
 			+ " ..:;;. ' .;;:..  \n"
 			+ "    .  '''  .     Type '/quit' to quit.\n"
 			+ "     :;,:,;:      Type '/help' for more options.\n"
@@ -57,7 +58,7 @@ public class RSBot {
 
 		// Create a handler for Perl as an object macro language.
 		File rsp4jFile = new File(RSBot.class.getClassLoader().getResource("lang/rsp4j.pl").getFile());
-		rs.setHandler("perl", new com.rivescript.lang.Perl(rs, rsp4jFile.getAbsolutePath()));
+		rs.setHandler("perl", new Perl(rs, rsp4jFile.getAbsolutePath()));
 
 		// Define an object macro in Java.
 		rs.setSubroutine("javatest", new ExampleMacro());


### PR DESCRIPTION
Removed the hardcoded `RiveScript.java` `VERSION` constant in favour of deriving the implementation version from the package itself.

Note that he implementation version is set in the in the jar creation by the Gradle build.

This way we only have to specify the version in `gradle.properties`.