### PR TITLE
Initial setup for Travis + automatic deploying to Sonatype

### DIFF
--- a/.travis-deploy-artifacts.sh
+++ b/.travis-deploy-artifacts.sh
@@ -10,6 +10,6 @@ fi
 
 # Deploy jar artifacts to Sonatype OSSRH
 
-openssl aes-256-cbc -pass pass:$SIGNING_PASSPHRASE -in secring.gpg.enc -out secring.gpg -d
+openssl aes-256-cbc -pass pass:$SIGNING_PASSWORD -in secring.gpg.enc -out secring.gpg -d
 
-./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/secring.gpg" uploadArchives
+./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSWORD" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/secring.gpg" uploadArchives

--- a/.travis-deploy-artifacts.sh
+++ b/.travis-deploy-artifacts.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+set +x
+
+# Do not deploy archives when building pull request
+if [ "$TRAVIS_BRANCH" != "master" ] || [ "$TRAVIS_PULL_REQUEST" == "true" ]; then
+  exit 0
+fi
+
+# Deploy jar artifacts to Sonatype OSSRH
+
+openssl aes-256-cbc -pass pass:$SIGNING_PASSPHRASE -in secring.gpg.enc -out secring.gpg -d
+
+./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/secring.gpg" uploadArchives

--- a/.travis-deploy-artifacts.sh
+++ b/.travis-deploy-artifacts.sh
@@ -10,6 +10,4 @@ fi
 
 # Deploy jar artifacts to Sonatype OSSRH
 
-openssl aes-256-cbc -pass pass:$SIGNING_PASSWORD -in secring.gpg.enc -out secring.gpg -d
-
 ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSWORD" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/secring.gpg" uploadArchives

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 sudo: false
 jdk:
 - oraclejdk7
+before_install:
+- openssl aes-256-cbc -K $encrypted_<hash>_key -iv $encrypted_<hash>_iv -in secring.gpg.enc -out secring.gpg -d
 after_success:
 - ./.travis-deploy-artifacts.sh
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: java
+sudo: false
+jdk:
+- oraclejdk7
+after_success:
+- ./.travis-deploy-artifacts.sh
+cache:
+  directories:
+  - $HOME/.gradle
+  - $HOME/.m2
+env:
+  global:
+  # SONATYPE_OSSRH_USERNAME
+  - secure:
+  # SONATYPE_OSSRH_PASSWORD
+  - secure:
+  # SIGNING_KEY
+  - secure:
+  # SIGNING_PASSPHRASE
+  - secure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ cache:
   - $HOME/.m2
 env:
   global:
+  # SIGNING_KEY
+  - secure:
+  # SIGNING_PASSWORD
+  - secure:
   # SONATYPE_OSSRH_USERNAME
   - secure:
   # SONATYPE_OSSRH_PASSWORD
-  - secure:
-  # SIGNING_KEY
-  - secure:
-  # SIGNING_PASSPHRASE
   - secure:

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,6 @@ buildscript {
 		mavenCentral()
 		mavenLocal()
 	}
-	dependencies {
-		classpath "nu.studer:gradle-credentials-plugin:1.0.1"
-	}
 }
 
 ext {
@@ -30,7 +27,6 @@ configure(allprojects) { project ->
 	apply plugin: "idea"
 	apply plugin: "maven"
 	apply plugin: "signing"
-	apply plugin: "nu.studer.credentials"
 
 	compileJava {
 		sourceCompatibility = 1.7
@@ -68,11 +64,6 @@ configure(allprojects) { project ->
 configure(subprojects - sampleprojects) { subproject ->
 
 	apply plugin: "signing"
-	apply plugin: "nu.studer.credentials"
-
-	ext."signing.keyId" = credentials.signingKeyId
-	ext."signing.password" = credentials.signingPassword
-	ext."signing.secretKeyRingFile" = credentials.signingSecretKeyRingFile
 
 	jar {
 		manifest.attributes["Created-By"] = "${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})"
@@ -103,6 +94,7 @@ configure(subprojects - sampleprojects) { subproject ->
 	}
 
 	signing {
+		required { gradle.taskGraph.hasTask("uploadArchives") }
 		sign configurations.archives
 	}
 
@@ -113,11 +105,11 @@ configure(subprojects - sampleprojects) { subproject ->
 				beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
 				repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-					authentication(userName: credentials.ossrhUsername, password: credentials.ossrhPassword)
+					authentication(userName: System.getenv("SONATYPE_OSSRH_USERNAME"), password: System.getenv("SONATYPE_OSSRH_PASSWORD"))
 				}
 
 				snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-					authentication(userName: credentials.ossrhUsername, password: credentials.ossrhPassword)
+					authentication(userName: System.getenv("SONATYPE_OSSRH_USERNAME"), password: System.getenv("SONATYPE_OSSRH_PASSWORD"))
 				}
 
 				pom.project {


### PR DESCRIPTION
Hi @kirsle 

Before looking into/merging this, please merge https://github.com/aichaos/rivescript-java/pull/23 first.

This PR should provide an initial setup for Travis + automatic deployment to Sonatype after commits.
Effectively this should currently deploy `*-SNAPSHOT` releases to the Sonatype Snapshot repository.

Things `you` need to do:

- [ ] Make sure you have a Sonatype JIRA account:  https://issues.sonatype.org/secure/Signup!default.jspa.
- [ ] Make sure you have your GPG secure ring and password.
- [ ] Add secure vars to `.travis.xml` (`SONATYPE_OSSRH_USERNAME`, `SONATYPE_OSSRH_PASSWORD`, `SIGNING_KEY` and `SIGNING_PASSPHRASE`. Just generate them using `travis encrypt SONATYPE_OSSRH_USERNAME=<your username>` and copy paste them in `.travis.xml`.
- [ ] Add encrypted `secring.gpg.enc` to root of repo. See https://docs.travis-ci.com/user/encrypting-files/ for details. You have to modify the `before_install` hook to use the correct `$` keys.
- [ ] Make sure to delete the `secring.gpg` from the repo folder.
- [ ] Add project to Travis.
- [ ] Cross your fingers and see if it works.

Honestly, I never didn't do it like this before, so I'm not sure it will work as expected and we might have to fine tune it. But I think it's a good first shot ;-)


