### PR TITLE
Huge performance improvement in StringUtils.quoteMetacharacters.

### DIFF
--- a/rivescript-core/src/main/java/com/rivescript/util/StringUtils.java
+++ b/rivescript-core/src/main/java/com/rivescript/util/StringUtils.java
@@ -22,11 +22,12 @@
 
 package com.rivescript.util;
 
-import com.rivescript.regexp.Regexp;
-
-import java.util.regex.Pattern;
-
 import static com.rivescript.regexp.Regexp.RE_NASTIES;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.rivescript.regexp.Regexp;
 
 /**
  * Miscellaneous {@link String} utility methods.
@@ -35,6 +36,30 @@ import static com.rivescript.regexp.Regexp.RE_NASTIES;
  * @author Marcel Overdijk
  */
 public class StringUtils {
+
+	private static final char ESCAPE_CHAR = '\\';
+	private static final Set<Character> UNSAFE_CHARS = new HashSet<Character>(); 
+	static {
+		UNSAFE_CHARS.add('\\');
+		UNSAFE_CHARS.add('.');
+		UNSAFE_CHARS.add('+');
+		UNSAFE_CHARS.add('*');
+		UNSAFE_CHARS.add('?');
+		UNSAFE_CHARS.add('[');
+		UNSAFE_CHARS.add('^');
+		UNSAFE_CHARS.add(']');
+		UNSAFE_CHARS.add('$');
+		UNSAFE_CHARS.add('(');
+		UNSAFE_CHARS.add(')');
+		UNSAFE_CHARS.add('{');
+		UNSAFE_CHARS.add('}');
+		UNSAFE_CHARS.add('=');
+		UNSAFE_CHARS.add('!');
+		UNSAFE_CHARS.add('<');
+		UNSAFE_CHARS.add('>');
+		UNSAFE_CHARS.add('|');
+		UNSAFE_CHARS.add(':');
+	}
 
 	/**
 	 * Counts the number of words in a {@link String}.
@@ -93,15 +118,21 @@ public class StringUtils {
 	 * @param str the string to escape
 	 * @return the escaped string
 	 */
-	public static String quoteMetacharacters(String str) {
+	public static String quoteMetacharacters(final String str) {
 		if (str == null) {
 			return null;
 		}
-		String unsafe = "\\.+*?[^]$(){}=!<>|:";
-		for (char c : unsafe.toCharArray()) {
-			str = str.replaceAll(Pattern.quote(Character.toString(c)), "\\\\\\" + c);
+
+		final StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < str.length(); i++) {
+			final char c = str.charAt(i);
+			if (UNSAFE_CHARS.contains(c)) {
+				sb.append(ESCAPE_CHAR);
+			}
+			sb.append(c);
 		}
-		return str;
+
+		return sb.toString();
 	}
 
 	/**
@@ -118,3 +149,4 @@ public class StringUtils {
 		return RE_NASTIES.matcher(str).replaceAll("");
 	}
 }
+


### PR DESCRIPTION
Hello,

After running performance tests in my company's app, method ``StringUtils.quoteMetacharacters`` shows up as consuming a lot of CPU time, around 25% of the time used by the Java Virtual Machine.

Analyzing the code, seems that the input string ``str`` ends up being fully iterated many times because of the ``replaceAll`` call for each of the ``unsafe`` chars.

This pull request changes the implementation to iterate only once through the entire input string. Each of its chars are checked only once and then escaped if needed. 

The unsafe chars are stored in a [HashSet](https://docs.oracle.com/javase/7/docs/api/java/util/HashSet.html),which is backed by a HashMap, so the ``contains`` check takes constant time to run.

These simple changes results in a huge improvement on the method performance (around 95%). Please consider releasing a new version as soon as possible. If you need anything, please let me know.

Best regards,
Márcio P. Dantas